### PR TITLE
Fix editing size not updating

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,12 @@
                     inputRef.current.select();
                 }
             }, [isEditing]);
+            // keep local size state in sync with guest prop
+            useEffect(() => {
+                if (!isEditing) {
+                    setSize(guest.size);
+                }
+            }, [guest.size, isEditing]);
             const handleSave = () => {
                 setIsEditing(false);
                 const newSize = parseInt(size, 10);


### PR DESCRIPTION
## Summary
- keep EditablePartySize input in sync with the guest size prop

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6865b77ec6548322856ecdc35ad48a1d