### PR TITLE
Update map container comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,9 +643,9 @@
                         </div>
 
                         <div className={`map-panel relative flex-grow bg-white p-4 rounded-xl shadow-lg ${activeView === 'map' ? 'flex' : 'hidden'} lg:flex flex-col`}>
-                             {/* Removed items-center and justify-center from mapContainerRef */}
+                             {/* Scrollable wrapper around the map */}
                              <div ref={mapContainerRef} className="w-full h-full overflow-auto" style={{ WebkitOverflowScrolling: 'touch' }}>
-                                 {/* Changed transformOrigin to 'top left' */}
+                                 {/* Scale content from the top-left corner so scrolling stays aligned */}
                                 <div ref={mapContentRef} style={{ transform: `scale(${scale})`, transformOrigin: 'top left' }} className="transition-transform duration-300 min-w-0 min-h-0">
                                     <div className="grid" style={{gridTemplateColumns: `repeat(${Math.max(...(tables.length > 0 ? tables.map(t=>t.gridCol) : [0])) + 1}, auto)`, gap: '1rem'}}>
                                         {tables.map(table => (


### PR DESCRIPTION
## Summary
- clarify map wrapper comment near `mapContainerRef`
- explain why `transformOrigin` uses `top left`

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6865b9e0620883228fc6f422921c000e