### PR TITLE
Add table color indicators

### DIFF
--- a/LayoutCreator.html
+++ b/LayoutCreator.html
@@ -112,7 +112,7 @@
                                         className={`w-full h-24 bg-gray-100 rounded border-2 border-dashed border-gray-300 hover:bg-green-100 hover:border-green-400 cursor-pointer flex items-center justify-center transition-colors`}
                                     >
                                        {tableHere ? (
-                                           <div className={`relative rounded p-1 ${tableHere.orientation === 'vertical' ? 'w-8 h-16' : 'w-16 h-8'} bg-red-400 flex items-center justify-center shadow-md`}>
+                                           <div className={`relative rounded p-1 ${tableHere.orientation === 'vertical' ? 'w-8 h-16' : 'w-16 h-8'} bg-green-400 flex items-center justify-center shadow-md`}>
                                                 <span className="text-white font-bold text-sm">{tableHere.displayId}</span>
                                                 <button onClick={(e) => handleDelete(e, tableHere.internalId)} className="absolute -top-2 -right-2 bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold leading-none hover:bg-red-700">&times;</button>
                                            </div>

--- a/index.html
+++ b/index.html
@@ -216,9 +216,21 @@
 
         const TableVisual = ({ table, assignedGuests, onClick, isSelectedGuest, orientation = 'vertical' }) => {
             const totalAssigned = assignedGuests.reduce((sum, g) => sum + g.size, 0);
+            const remainingSeats = table.capacity - totalAssigned;
+            let tableColor = 'bg-green-400';
+            if (remainingSeats <= 2) {
+                tableColor = 'bg-red-400';
+            } else if (remainingSeats <= 6) {
+                tableColor = 'bg-yellow-400';
+            }
             const renderChairs = (count, filledCount, layoutClass) => (
                 <div className={`flex ${layoutClass}`}>
-                    {Array.from({ length: count }).map((_, i) => (<div key={i} className={`w-3.5 h-3.5 rounded-sm ${i < filledCount ? 'bg-indigo-500' : 'bg-gray-300'}`}></div>))}
+                    {Array.from({ length: count }).map((_, i) => (
+                        <div
+                            key={i}
+                            className={`w-3.5 h-3.5 rounded-sm ${i < filledCount ? 'bg-indigo-500' : 'bg-gray-300'}`}
+                        ></div>
+                    ))}
                 </div>
             );
             const hoverClass = isSelectedGuest ? 'hover:outline-blue-500 hover:bg-blue-100' : '';
@@ -229,7 +241,7 @@
                             {renderChairs(4, totalAssigned, 'gap-2 mb-1')}
                              <div className="flex items-center gap-1">
                                 {renderChairs(1, Math.max(0, totalAssigned - 4), '')}
-                                <div className="relative bg-red-400 rounded h-10 w-16 flex items-center justify-center text-white font-bold text-sm">{table.displayId}</div>
+                                <div className={`relative ${tableColor} rounded h-10 w-16 flex items-center justify-center text-white font-bold text-sm`}>{table.displayId}</div>
                                 {renderChairs(1, Math.max(0, totalAssigned - 5), '')}
                             </div>
                             {renderChairs(4, Math.max(0, totalAssigned - 6), 'gap-2 mt-1')}
@@ -239,7 +251,7 @@
                             {renderChairs(4, totalAssigned, 'flex-col gap-2 mr-1')}
                             <div className="flex flex-col items-center gap-1">
                                {renderChairs(1, Math.max(0, totalAssigned - 4), '')}
-                               <div className="relative bg-red-400 rounded w-10 h-16 flex items-center justify-center text-white font-bold text-sm">{table.displayId}</div>
+                               <div className={`relative ${tableColor} rounded w-10 h-16 flex items-center justify-center text-white font-bold text-sm`}>{table.displayId}</div>
                                {renderChairs(1, Math.max(0, totalAssigned - 5), '')}
                             </div>
                             {renderChairs(4, Math.max(0, totalAssigned - 6), 'flex-col gap-2 ml-1')}


### PR DESCRIPTION
## Summary
- default tables display green
- add dynamic color changes based on remaining seats

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_6865ca347c188322b6bbf9fe5284c958