### PR TITLE
Hide zoom buttons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@
 
         const ZoomControls = ({ onZoomIn, onZoomOut, onReset }) => {
             return (
-                <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-2">
+                <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-2 hidden lg:flex">
                     <button onClick={onZoomIn} className="bg-gray-700 text-white rounded-full w-10 h-10 flex items-center justify-center shadow-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 text-xl">+</button>
                     <button onClick={onZoomOut} className="bg-gray-700 text-white rounded-full w-10 h-10 flex items-center justify-center shadow-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 text-xl">-</button>
                     <button onClick={onReset} className="bg-gray-700 text-white rounded-full w-10 h-10 flex items-center justify-center shadow-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 text-xs">Reset</button>


### PR DESCRIPTION
## Summary
- hide zoom controls when viewport is less than `lg`

## Testing
- `node test/validateLayouts.js`

------
https://chatgpt.com/codex/tasks/task_e_686602a646dc83228ed675a845bb3eaa