### PR TITLE
Fix iOS keyboard focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,9 +73,7 @@
             const [size, setSize] = useState(guest.size);
             const inputRef = useRef(null);
             useEffect(() => {
-                // Added a check for inputRef.current to ensure it's not null before accessing
                 if (isEditing && inputRef.current) {
-                    inputRef.current.focus();
                     inputRef.current.select();
                 }
             }, [isEditing]);
@@ -99,7 +97,7 @@
                 <div className="flex items-center space-x-1 text-indigo-600">
                     <UserIcon className="w-5 h-5" />
                     {isEditing ? (
-                        <input ref={inputRef} type="number" value={size} onChange={(e) => setSize(e.target.value)} onBlur={handleSave} onKeyDown={handleKeyDown} className="w-12 text-center font-bold text-lg bg-white border border-indigo-300 rounded" min="0"/>
+                        <input ref={inputRef} autoFocus type="number" value={size} onChange={(e) => setSize(e.target.value)} onBlur={handleSave} onKeyDown={handleKeyDown} className="w-12 text-center font-bold text-lg bg-white border border-indigo-300 rounded" min="0"/>
                     ) : (
                         <span className="font-bold text-lg cursor-pointer px-2 py-1 rounded hover:bg-indigo-100" onClick={(e) => { e.stopPropagation(); setIsEditing(true);}}>{guest.size}</span>
                     )}
@@ -118,9 +116,9 @@
             useEffect(() => {
                 if (isEditing && textareaRef.current) {
                     const textarea = textareaRef.current;
-                    textarea.focus();
                     textarea.style.height = 'auto';
                     textarea.style.height = `${textarea.scrollHeight}px`;
+                    textarea.select();
                 }
             }, [isEditing]);
 
@@ -153,6 +151,7 @@
                     {isEditing ? (
                         <textarea
                             ref={textareaRef}
+                            autoFocus
                             value={note}
                             onChange={handleTextChange}
                             onBlur={handleSave}
@@ -333,7 +332,7 @@
                     <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-xl p-6 w-full max-w-sm" onClick={(e) => e.stopPropagation()}>
                         <h2 className="text-2xl font-bold text-gray-800 mb-6">Add New Party</h2>
                         <div className="space-y-4">
-                            <div><label htmlFor="partyName" className="block text-sm font-medium text-gray-700">Party Name</label><input type="text" id="partyName" value={name} onChange={(e) => setName(e.target.value)} required className="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" /></div>
+                            <div><label htmlFor="partyName" className="block text-sm font-medium text-gray-700">Party Name</label><input type="text" id="partyName" value={name} onChange={(e) => setName(e.target.value)} required autoFocus className="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" /></div>
                             <div><label htmlFor="partySize" className="block text-sm font-medium text-gray-700">Party Size</label><input type="number" id="partySize" value={size} onChange={(e) => setSize(e.target.value)} required min="1" className="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" /></div>
                         </div>
                         <div className="mt-6 flex justify-end space-x-3"><button type="button" onClick={onClose} className="bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors">Cancel</button><button type="submit" className="bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors">Add Party</button></div>


### PR DESCRIPTION
## Summary
- ensure text inputs receive focus automatically by using the `autoFocus` attribute
- simplify focus logic for editable fields

## Testing
- `node test/validateLayouts.js`


------
https://chatgpt.com/codex/tasks/task_e_68711ae92e28832295f58b892f1d60a9