### PR TITLE
Add estimated tables needed to guest list

### DIFF
--- a/index.html
+++ b/index.html
@@ -994,7 +994,7 @@
                         <div className={`guest-list-panel flex-grow min-h-0 lg:flex-grow-0 lg:w-96 lg:flex-shrink-0 bg-white rounded-xl shadow-lg border border-gray-200 flex flex-col h-full ${activeView === 'list' ? 'flex' : 'hidden'} lg:flex`}>
 
                             <div className="flex justify-between items-center p-4 border-b flex-shrink-0">
-                                <h2 className="text-xl font-bold text-gray-700">Guest Parties ({unassignedGuests.length}) \u2022 Est. Tables: {estimatedTables}</h2>
+                                <h2 className="text-xl font-bold text-gray-700">Guest Parties ({unassignedGuests.length}) - Est. Tables: {estimatedTables}</h2>
                                 <button onClick={() => setIsAddPartyModalOpen(true)} className="bg-indigo-600 text-white rounded-full p-2 hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" /></svg>
                                 </button>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
 
     <script type="text/babel">
         const { useState, useMemo, useRef, useEffect } = React;
+        const DEFAULT_TABLE_CAPACITY = 10;
 
 
         // --- Helper Components ---
@@ -434,7 +435,7 @@
             const layoutFileInputRef = useRef(null);
 	    
 
-            const { unassignedGuests, tableAssignments } = useMemo(() => {
+            const { unassignedGuests, tableAssignments, estimatedTables } = useMemo(() => {
                 const unassigned = [];
                 const tableAssignmentsMap = tables.reduce((acc, table) => { acc[table.internalId] = { guests: [], remainingSeats: table.capacity }; return acc; }, {});
                 guests.forEach(guest => {
@@ -444,7 +445,24 @@
                         tableAssignmentsMap[assignedTableId].remainingSeats -= guest.size;
                     } else { unassigned.push(guest); }
                 });
-                return { unassignedGuests: unassigned.sort((a,b) => a.id.localeCompare(b.id, undefined, {numeric: true})), tableAssignments: tableAssignmentsMap };
+
+                const capacities = [];
+                const sorted = unassigned.slice().sort((a,b) => b.size - a.size);
+                sorted.forEach(g => {
+                    let placed = false;
+                    for (let i = 0; i < capacities.length; i++) {
+                        if (capacities[i] >= g.size) {
+                            capacities[i] -= g.size;
+                            placed = true;
+                            break;
+                        }
+                    }
+                    if (!placed) {
+                        capacities.push(DEFAULT_TABLE_CAPACITY - g.size);
+                    }
+                });
+
+                return { unassignedGuests: unassigned.sort((a,b) => a.id.localeCompare(b.id, undefined, {numeric: true})), tableAssignments: tableAssignmentsMap, estimatedTables: capacities.length };
             }, [assignments, guests, tables]);
             
 
@@ -976,7 +994,7 @@
                         <div className={`guest-list-panel flex-grow min-h-0 lg:flex-grow-0 lg:w-96 lg:flex-shrink-0 bg-white rounded-xl shadow-lg border border-gray-200 flex flex-col h-full ${activeView === 'list' ? 'flex' : 'hidden'} lg:flex`}>
 
                             <div className="flex justify-between items-center p-4 border-b flex-shrink-0">
-                                <h2 className="text-xl font-bold text-gray-700">Guest Parties ({unassignedGuests.length})</h2>
+                                <h2 className="text-xl font-bold text-gray-700">Guest Parties ({unassignedGuests.length}) \u2022 Est. Tables: {estimatedTables}</h2>
                                 <button onClick={() => setIsAddPartyModalOpen(true)} className="bg-indigo-600 text-white rounded-full p-2 hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" /></svg>
                                 </button>


### PR DESCRIPTION
## Summary
- calculate estimated tables needed for unassigned guests using a greedy algorithm
- display this estimate next to the guest party count in the guest list header

## Testing
- `node test/validateLayouts.js`

------
https://chatgpt.com/codex/tasks/task_e_687edc9d405883229540faff4c7b63cc