### PR TITLE
Sort guest lists alphabetically

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,12 +292,13 @@
 
         const ReservationDetailsModal = ({ table, guests, onClose, onUnassign, onReassign, onSizeChange }) => {
             if (!table) return null;
+            const sortedGuests = guests.slice().sort((a,b) => a.name.localeCompare(b.name, undefined, {sensitivity: 'base'}));
             return (
                 <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4" onClick={onClose}>
                     <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md" onClick={(e) => e.stopPropagation()}>
                          <h2 className="text-2xl font-bold text-gray-800 mb-4">Table {table.displayId} Details</h2>
-                        {guests.length > 0 ? (
-                            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">{guests.map(guest => (
+                        {sortedGuests.length > 0 ? (
+                            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">{sortedGuests.map(guest => (
                                 <div key={guest.id} className="bg-gray-50 p-4 rounded-lg border">
                                     <div className="flex justify-between items-start">
                                         <h3 className="font-bold text-lg text-gray-900">{guest.name}</h3>
@@ -479,7 +480,11 @@
                     }
                 });
 
-                return { unassignedGuests: unassigned.sort((a,b) => a.id.localeCompare(b.id, undefined, {numeric: true})), tableAssignments: tableAssignmentsMap, estimatedTables: capacities.length };
+                Object.values(tableAssignmentsMap).forEach(t => {
+                    t.guests.sort((a,b) => a.name.localeCompare(b.name, undefined, {sensitivity: 'base'}));
+                });
+
+                return { unassignedGuests: unassigned.sort((a,b) => a.name.localeCompare(b.name, undefined, {sensitivity: 'base'})), tableAssignments: tableAssignmentsMap, estimatedTables: capacities.length };
             }, [assignments, guests, tables]);
             
 


### PR DESCRIPTION
## Summary
- alphabetically sort unassigned guests and table guest lists by name

## Testing
- `node test/validateLayouts.js`

------
https://chatgpt.com/codex/tasks/task_e_688b816acc748322afc726781e368347