### PR TITLE
Support multi-table seating and unmerge

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,12 +230,18 @@
             );
         };
 
-        const GuestCard = ({ guest, onSizeChange, onNotesChange, isSelected, onClick }) => {
+        const GuestCard = ({ guest, onSizeChange, onNotesChange, isSelected, onClick, onMerge, onUnmerge }) => {
           return (
-            <div onClick={onClick} className={`p-3 mb-2 rounded-lg shadow-md cursor-pointer flex flex-col items-start justify-center text-sm transition-all duration-200 ease-in-out bg-white hover:bg-gray-50 ${isSelected ? 'ring-2 ring-blue-500' : 'ring-1 ring-transparent'}`}> 
+            <div onClick={onClick} className={`p-3 mb-2 rounded-lg shadow-md cursor-pointer flex flex-col items-start justify-center text-sm transition-all duration-200 ease-in-out bg-white hover:bg-gray-50 ${isSelected ? 'ring-2 ring-blue-500' : 'ring-1 ring-transparent'}`}>
               <div className="flex items-center justify-between w-full">
                 <span className="font-semibold text-gray-800">{guest.name}</span>
-                <EditablePartySize guest={guest} onSizeChange={onSizeChange} />
+                <div className="flex items-center gap-1">
+                  <EditablePartySize guest={guest} onSizeChange={onSizeChange} />
+                  <button onClick={(e) => { e.stopPropagation(); onMerge(guest.id); }} className="bg-blue-500 text-white text-xs px-1 rounded hover:bg-blue-600">Merge</button>
+                  {guest.children && guest.children.length > 1 && (
+                    <button onClick={(e) => { e.stopPropagation(); onUnmerge(guest.id); }} className="bg-yellow-500 text-white text-xs px-1 rounded hover:bg-yellow-600">Unmerge</button>
+                  )}
+                </div>
               </div>
               <EditableNote guest={guest} onNotesChange={onNotesChange} />
             </div>
@@ -290,26 +296,34 @@
             );
         };
 
-        const ReservationDetailsModal = ({ table, guests, onClose, onUnassign, onReassign, onSizeChange }) => {
+        const ReservationDetailsModal = ({ table, guests, tables, onClose, onUnassign, onReassign, onSizeChange, onMerge, onUnmerge }) => {
             if (!table) return null;
             return (
                 <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4" onClick={onClose}>
                     <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md" onClick={(e) => e.stopPropagation()}>
                          <h2 className="text-2xl font-bold text-gray-800 mb-4">Table {table.displayId} Details</h2>
                         {guests.length > 0 ? (
-                            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">{guests.map(guest => (
-                                <div key={guest.id} className="bg-gray-50 p-4 rounded-lg border">
-                                    <div className="flex justify-between items-start">
-                                        <h3 className="font-bold text-lg text-gray-900">{guest.name}</h3>
-                                        <div className="flex flex-wrap items-center gap-2">
-                                            <EditablePartySize guest={guest} onSizeChange={onSizeChange} />
-                                            <button onClick={() => onReassign(guest.id)} className="bg-green-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-green-600">Reassign</button>
-                                            <button onClick={() => onUnassign(guest.id)} className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-red-600">Unassign</button>
+                            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">{guests.map(guest => {
+                                const otherTables = guest.tableIds.filter(id => id !== table.internalId).map(id => tables.find(t => t.internalId === id)?.displayId).filter(Boolean);
+                                return (
+                                    <div key={guest.segmentIds.join('|')} className="bg-gray-50 p-4 rounded-lg border">
+                                        <div className="flex justify-between items-start">
+                                            <h3 className="font-bold text-lg text-gray-900">{guest.name}</h3>
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <EditablePartySize guest={guest} onSizeChange={onSizeChange} />
+                                                <button onClick={() => onMerge(guest.segmentIds[0])} className="bg-blue-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-blue-600">Merge</button>
+                                                {guest.children && guest.children.length > 1 && (
+                                                    <button onClick={() => onUnmerge(guest.segmentIds[0])} className="bg-yellow-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-yellow-600">Unmerge</button>
+                                                )}
+                                                <button onClick={() => onReassign(guest.segmentIds[0])} className="bg-green-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-green-600">Reassign</button>
+                                                <button onClick={() => onUnassign(guest.segmentIds)} className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-red-600">Unassign</button>
+                                            </div>
                                         </div>
+                                        {guest.notes && <p className="text-gray-600 mt-2 whitespace-pre-wrap"><strong>Notes:</strong> {guest.notes}</p>}
+                                        {otherTables.length > 0 && <p className="text-xs text-gray-500 mt-1">Also seated at: {otherTables.join(', ')}</p>}
                                     </div>
-                                    {guest.notes && <p className="text-gray-600 mt-2 whitespace-pre-wrap"><strong>Notes:</strong> {guest.notes}</p>}
-                                </div>
-                            ))}</div>
+                                );
+                            })}</div>
                         ) : (<p className="text-gray-600">This table is currently empty.</p>)}
                         <button onClick={onClose} className="mt-6 w-full bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors">Close</button>
                     </div>
@@ -403,6 +417,7 @@
             const [assignments, setAssignments] = useState({});
             const [notification, setNotification] = useState(null);
             const [selectedGuestId, setSelectedGuestId] = useState(null);
+            const [mergeSourceId, setMergeSourceId] = useState(null);
             const [modalData, setModalData] = useState(null);
             const [isAddPartyModalOpen, setIsAddPartyModalOpen] = useState(false);
             const [activeView, setActiveView] = useState('list');
@@ -869,7 +884,48 @@
                 if (newSize === 0) {
                     setConfirmModalState({ isOpen: true, guestId: guestId });
                 } else {
-                    setGuests(currentGuests => currentGuests.map(g => g.id === guestId ? { ...g, size: newSize } : g));
+                    const keyFor = g => g.children && g.children.map(c => c.id).sort().join('|');
+                    const guest = guests.find(g => g.id === guestId);
+
+                    setGuests(currentGuests => {
+                        if (!guest) return currentGuests;
+                        const groupKey = keyFor(guest);
+                        const relatedGuests = groupKey ? currentGuests.filter(g => keyFor(g) === groupKey) : [];
+
+                        let updatedChildren = guest.children;
+                        if (guest.children && guest.children.length > 1) {
+                            const totalOtherSegments = relatedGuests.filter(g => g.id !== guestId).reduce((sum, g) => sum + g.size, 0);
+                            let desiredTotal = newSize + totalOtherSegments;
+                            const minTotal = guest.children.length;
+                            if (desiredTotal < minTotal) desiredTotal = minTotal;
+
+                            const childCopy = guest.children.map(c => ({ ...c }));
+                            let currentTotal = childCopy.reduce((sum, c) => sum + c.size, 0);
+                            let diff = desiredTotal - currentTotal;
+
+                            if (diff >= 0) {
+                                childCopy[0].size += diff;
+                            } else {
+                                for (let i = 0; i < childCopy.length && diff < 0; i++) {
+                                    const reducible = Math.min(childCopy[i].size - 1, -diff);
+                                    childCopy[i].size -= reducible;
+                                    diff += reducible;
+                                }
+                            }
+                            updatedChildren = childCopy;
+                        }
+
+                        return currentGuests.map(g => {
+                            if (g.id === guestId) {
+                                return { ...g, size: newSize, children: updatedChildren };
+                            }
+                            if (groupKey && keyFor(g) === groupKey) {
+                                return { ...g, children: updatedChildren };
+                            }
+                            return g;
+                        });
+                    });
+
                     const assignedTableId = assignments[guestId];
                     if (assignedTableId) {
                         const tableData = tables.find(t => t.internalId === assignedTableId);
@@ -877,7 +933,6 @@
                         const newTotal = currentTableGuests.reduce((sum, g) => sum + g.size, 0) + newSize;
                         if (newTotal > tableData.capacity) {
                             unassignGuest(guestId);
-                            // Find the guest name for the notification
                             const guestToUpdate = guests.find(g => g.id === guestId);
                             displayNotification(`"${guestToUpdate.name}" unassigned: new size (${newSize}) exceeds table capacity.`, 'info');
                         }
@@ -896,7 +951,21 @@
                 setConfirmModalState({ isOpen: false, guestId: null });
             };
             
-            const handleGuestNotesChange = (guestId, newNotes) => { setGuests(currentGuests => currentGuests.map(g => g.id === guestId ? { ...g, notes: newNotes } : g)); };
+            const handleGuestNotesChange = (guestId, newNotes) => {
+                const keyFor = g => g.children && g.children.map(c => c.id).sort().join('|');
+                const guest = guests.find(g => g.id === guestId);
+                setGuests(currentGuests => {
+                    if (!guest || !guest.children) {
+                        return currentGuests.map(g => g.id === guestId ? { ...g, notes: newNotes } : g);
+                    }
+                    const groupKey = keyFor(guest);
+                    return currentGuests.map(g =>
+                        (g.id === guestId || (groupKey && keyFor(g) === groupKey))
+                            ? { ...g, notes: newNotes }
+                            : g
+                    );
+                });
+            };
 
             const handleAddParty = (name, size) => {
                 const newParty = { id: `new-g-${Date.now()}`, name, size, notes: '' };
@@ -906,8 +975,25 @@
             const assignGuestToTable = (guestId, tableId) => {
                 const guest = guests.find(g => g.id === guestId);
                 const { remainingSeats } = tableAssignments[tableId];
-                if (!guest) return;
-                if (guest.size > remainingSeats) {
+                const table = tables.find(t => t.internalId === tableId);
+                if (!guest || !table) return;
+                if (guest.size > DEFAULT_TABLE_CAPACITY) {
+                    const seatsThisTable = Math.min(DEFAULT_TABLE_CAPACITY, remainingSeats, table.capacity, guest.size);
+                    if (seatsThisTable <= 0) { displayNotification(`Party of ${guest.size} is too large for this table.`, 'error'); return; }
+                    const remainder = guest.size - seatsThisTable;
+                    const updatedGuest = { ...guest, size: seatsThisTable };
+                    const newGuestList = guests.map(g => g.id === guestId ? updatedGuest : g);
+                    if (remainder > 0) {
+                        const newId = `split-${Date.now()}`;
+                        newGuestList.push({ ...guest, id: newId, size: remainder });
+                        setSelectedGuestId(newId);
+                        displayNotification(`Select a table for remaining ${remainder} guests of "${guest.name}"`, 'info');
+                    } else {
+                        setSelectedGuestId(null);
+                    }
+                    setGuests(newGuestList);
+                    setAssignments(prev => ({ ...prev, [guestId]: tableId }));
+                } else if (guest.size > remainingSeats) {
                     displayNotification(`Party of ${guest.size} is too large for this table.`, 'error');
                 } else {
                     setAssignments(prev => ({ ...prev, [guestId]: tableId }));
@@ -916,7 +1002,90 @@
             };
             const unassignGuest = (guestId) => { if (assignments[guestId]) { setAssignments(prev => { const newAssignments = { ...prev }; delete newAssignments[guestId]; return newAssignments; }); } };
 
+            const handleStartMerge = (guestId) => {
+                if (mergeSourceId && mergeSourceId !== guestId) {
+                    mergeGuests(mergeSourceId, guestId);
+                    return;
+                }
+                if (mergeSourceId === guestId) {
+                    setMergeSourceId(null);
+                    setSelectedGuestId(null);
+                    displayNotification('Merge cancelled.', 'info');
+                    return;
+                }
+                const guest = guests.find(g => g.id === guestId);
+                if (!guest) return;
+                setMergeSourceId(guestId);
+                setSelectedGuestId(null);
+                setModalData(null);
+                displayNotification(`Select another party to merge with "${guest.name}".`, 'info');
+            };
+
+            const handleUnmerge = (guestId) => {
+                unmergeGuest(guestId);
+            };
+
+            const mergeGuests = (fromId, toId) => {
+                if (!fromId || fromId === toId) { setMergeSourceId(null); return; }
+                const fromGuest = guests.find(g => g.id === fromId);
+                const toGuest = guests.find(g => g.id === toId);
+                if (!fromGuest || !toGuest) { setMergeSourceId(null); return; }
+
+                const keyFor = g => g.children && g.children.map(c => c.id).sort().join('|');
+                const getChildren = g => g.children ? g.children : [{ id: g.id, name: g.name, size: g.size, notes: g.notes }];
+                const getSegments = guest => {
+                    const key = keyFor(guest);
+                    return key ? guests.filter(g => keyFor(g) === key) : [guest];
+                };
+
+                const segments = [...getSegments(fromGuest), ...getSegments(toGuest)];
+                const childMap = new Map();
+                segments.forEach(seg => {
+                    getChildren(seg).forEach(child => childMap.set(child.id, child));
+                });
+                const mergedChildren = Array.from(childMap.values());
+                const mergedSize = mergedChildren.reduce((sum, c) => sum + c.size, 0);
+                const mergedName = mergedChildren.map(c => c.name).join(' + ');
+                const mergedNotes = segments.map(s => s.notes).filter(Boolean).join('\n');
+
+                const merged = { id: `merged-${Date.now()}`, name: mergedName, size: mergedSize, notes: mergedNotes, children: mergedChildren };
+
+                const remaining = guests.filter(g => !segments.some(s => s.id === g.id));
+                setGuests([...remaining, merged]);
+                segments.forEach(s => unassignGuest(s.id));
+                setSelectedGuestId(null);
+                displayNotification(`Merged "${fromGuest.name}" with "${toGuest.name}"`, 'info');
+                setMergeSourceId(null);
+            };
+
+            const unmergeGuest = (guestId) => {
+                const guest = guests.find(g => g.id === guestId);
+                if (!guest || !guest.children) return;
+
+                const keyFor = g => g.children && g.children.map(c => c.id).sort().join('|');
+                const targetKey = keyFor(guest);
+
+                const toRemove = guests.filter(g => keyFor(g) === targetKey);
+                let newGuests = guests.filter(g => !toRemove.some(r => r.id === g.id));
+
+                toRemove.forEach(g => unassignGuest(g.id));
+
+                guest.children.forEach(child => {
+                    newGuests.push({ ...child });
+                    unassignGuest(child.id);
+                });
+
+                setGuests(newGuests);
+                setSelectedGuestId(null);
+                setMergeSourceId(null);
+                displayNotification(`Unmerged "${guest.name}"`, 'info');
+            };
+
             const handleGuestCardClick = (guestId) => {
+                if (mergeSourceId) {
+                    mergeGuests(mergeSourceId, guestId);
+                    return;
+                }
                 if (selectedGuestId === guestId) {
                     setSelectedGuestId(null);
                 } else {
@@ -928,6 +1097,7 @@
             };
 
             const handleTableClick = (table) => {
+                if (mergeSourceId) return;
                 if (selectedGuestId) {
                     assignGuestToTable(selectedGuestId, table.internalId);
                 } else {
@@ -935,8 +1105,8 @@
                 }
             };
 
-            const handleUnassignInModal = (guestId) => {
-                unassignGuest(guestId);
+            const handleUnassignInModal = (ids) => {
+                ids.forEach(id => unassignGuest(id));
             };
 
             const startApp = () => {
@@ -964,7 +1134,24 @@
              
             const guestToConfirm = guests.find(g => g.id === confirmModalState.guestId);
             const modalTable = modalData ? tables.find(t => t.internalId === modalData.tableId) : null;
-            const modalGuests = modalData ? tableAssignments[modalData.tableId]?.guests || [] : [];
+            const modalGuests = useMemo(() => {
+                if (!modalData) return [];
+                const tableId = modalData.tableId;
+                const guestsAtTable = tableAssignments[tableId]?.guests || [];
+                const keyFor = g => g.children && g.children.map(c => c.id).sort().join('|');
+                const aggregated = [];
+                const processed = new Set();
+                guestsAtTable.forEach(g => {
+                    const key = keyFor(g) || g.id;
+                    if (processed.has(key)) return;
+                    const segments = guests.filter(seg => (keyFor(seg) || seg.id) === key && assignments[seg.id]);
+                    const totalSize = segments.reduce((sum, seg) => sum + seg.size, 0);
+                    const tableIds = [...new Set(segments.map(seg => assignments[seg.id]))];
+                    aggregated.push({ ...g, size: totalSize, segmentIds: segments.map(seg => seg.id), tableIds });
+                    processed.add(key);
+                });
+                return aggregated;
+            }, [modalData, tableAssignments, guests, assignments]);
 
             return (
 
@@ -988,7 +1175,7 @@
                     >
                         Are you sure you want to remove the party "<strong>{guestToConfirm?.name}</strong>"? This action cannot be undone.
                     </ConfirmationModal>
-                    <ReservationDetailsModal table={modalTable} guests={modalGuests} onClose={() => setModalData(null)} onUnassign={handleUnassignInModal} onReassign={handleReassignInModal} onSizeChange={handleGuestSizeChange} />
+                <ReservationDetailsModal table={modalTable} guests={modalGuests} tables={tables} onClose={() => setModalData(null)} onUnassign={handleUnassignInModal} onReassign={handleReassignInModal} onSizeChange={handleGuestSizeChange} onMerge={handleStartMerge} onUnmerge={handleUnmerge} />
                     <AddPartyModal isOpen={isAddPartyModalOpen} onClose={() => setIsAddPartyModalOpen(false)} onAddParty={handleAddParty} />
 
                     <header className="landscape-header p-4 sm:p-6 lg:p-4 w-full flex-shrink-0">
@@ -1024,7 +1211,7 @@
                                 </button>
                             </div>
                             <div className="overflow-y-auto flex-grow p-4" style={{ WebkitOverflowScrolling: 'touch' }}>
-                                {guests.length > 0 ? ( unassignedGuests.map(guest => <GuestCard key={guest.id} guest={guest} onSizeChange={handleGuestSizeChange} onNotesChange={handleGuestNotesChange} isSelected={selectedGuestId === guest.id} onClick={() => handleGuestCardClick(guest.id)} />)
+                                {guests.length > 0 ? ( unassignedGuests.map(guest => <GuestCard key={guest.id} guest={guest} onSizeChange={handleGuestSizeChange} onNotesChange={handleGuestNotesChange} isSelected={selectedGuestId === guest.id} onClick={() => handleGuestCardClick(guest.id)} onMerge={handleStartMerge} onUnmerge={handleUnmerge} />)
                                 ) : (<div className="text-center text-gray-500 mt-10 p-4 bg-gray-50 rounded-lg"><h3 className="font-semibold text-lg">No Guests</h3><p className="text-sm">Import a guest list to get started.</p></div>)}
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- add Unmerge buttons and handler to restore merged parties
- split large parties across multiple tables when assigning
- keep children info when merging parties
- fix unmerge to remove all split pieces of a merged party
- fix merged party size edits to update original child sizes
- synchronize notes across merged segments
- cancel merge when tapping the same party again
- merge all split segments together and dedupe children
- clear merge state when unmerging or cancelling
- group merged parties across multiple tables in table details

## Testing
- `node test/validateLayouts.js`


------
https://chatgpt.com/codex/tasks/task_e_68823926bc20832293f9f82b2ca11546