### PR TITLE
Enable large party splitting

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,20 +230,21 @@
             );
         };
 
-        const GuestCard = ({ guest, onSizeChange, onNotesChange, isSelected, onClick }) => {
+        const GuestCard = ({ guest, remaining, onSizeChange, onNotesChange, isSelected, onClick }) => {
           return (
-            <div onClick={onClick} className={`p-3 mb-2 rounded-lg shadow-md cursor-pointer flex flex-col items-start justify-center text-sm transition-all duration-200 ease-in-out bg-white hover:bg-gray-50 ${isSelected ? 'ring-2 ring-blue-500' : 'ring-1 ring-transparent'}`}> 
+            <div onClick={onClick} className={`p-3 mb-2 rounded-lg shadow-md cursor-pointer flex flex-col items-start justify-center text-sm transition-all duration-200 ease-in-out bg-white hover:bg-gray-50 ${isSelected ? 'ring-2 ring-blue-500' : 'ring-1 ring-transparent'}`}>
               <div className="flex items-center justify-between w-full">
                 <span className="font-semibold text-gray-800">{guest.name}</span>
                 <EditablePartySize guest={guest} onSizeChange={onSizeChange} />
               </div>
+              {remaining < guest.size && <p className="text-xs text-gray-600">Remaining: {remaining} of {guest.size}</p>}
               <EditableNote guest={guest} onNotesChange={onNotesChange} />
             </div>
           );
         };
 
         const TableVisual = ({ table, assignedGuests, onClick, isSelectedGuest, orientation = 'vertical' }) => {
-            const totalAssigned = assignedGuests.reduce((sum, g) => sum + g.size, 0);
+            const totalAssigned = assignedGuests.reduce((sum, g) => sum + g.assignedSeats, 0);
             const remainingSeats = table.capacity - totalAssigned;
             let tableColor = 'bg-green-400';
             if (remainingSeats <= 2) {
@@ -290,25 +291,27 @@
             );
         };
 
-        const ReservationDetailsModal = ({ table, guests, onClose, onUnassign, onReassign, onSizeChange }) => {
+        const ReservationDetailsModal = ({ table, guests, assignments, tables, onClose, onUnassign, onReassign, onSizeChange }) => {
             if (!table) return null;
-            const sortedGuests = guests.slice().sort((a,b) => a.name.localeCompare(b.name, undefined, {sensitivity: 'base'}));
+            const sortedGuests = guests.slice().sort((a,b) => a.guest.name.localeCompare(b.guest.name, undefined, {sensitivity: 'base'}));
             return (
                 <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4" onClick={onClose}>
                     <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md" onClick={(e) => e.stopPropagation()}>
                          <h2 className="text-2xl font-bold text-gray-800 mb-4">Table {table.displayId} Details</h2>
                         {sortedGuests.length > 0 ? (
-                            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">{sortedGuests.map(guest => (
-                                <div key={guest.id} className="bg-gray-50 p-4 rounded-lg border">
+                            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">{sortedGuests.map(item => (
+                                <div key={item.guest.id} className="bg-gray-50 p-4 rounded-lg border">
                                     <div className="flex justify-between items-start">
-                                        <h3 className="font-bold text-lg text-gray-900">{guest.name}</h3>
+                                        <h3 className="font-bold text-lg text-gray-900">{item.guest.name}</h3>
                                         <div className="flex flex-wrap items-center gap-2">
-                                            <EditablePartySize guest={guest} onSizeChange={onSizeChange} />
-                                            <button onClick={() => onReassign(guest.id)} className="bg-green-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-green-600">Reassign</button>
-                                            <button onClick={() => onUnassign(guest.id)} className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-red-600">Unassign</button>
+                                            <EditablePartySize guest={item.guest} onSizeChange={onSizeChange} />
+                                            <button onClick={() => onReassign(item.guest.id)} className="bg-green-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-green-600">Reassign</button>
+                                            <button onClick={() => onUnassign(item.guest.id)} className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded hover:bg-red-600">Unassign</button>
                                         </div>
                                     </div>
-                                    {guest.notes && <p className="text-gray-600 mt-2 whitespace-pre-wrap"><strong>Notes:</strong> {guest.notes}</p>}
+                                    <p className="text-gray-600 text-sm">Seats at this table: {item.assignedSeats} of {item.guest.size}</p>
+                                    {(() => { const parts = assignments[item.guest.id] || []; const others = parts.filter(p => p.tableId !== table.internalId); if (others.length > 0) { const names = others.map(p => { const t = tables.find(tt => tt.internalId === p.tableId); return `${t ? t.displayId : p.tableId} (${p.seats})`; }).join(', '); return <p className="text-gray-600 text-xs">Others at table{others.length>1?'s':''} {names}</p>; } return null; })()}
+                                    {item.guest.notes && <p className="text-gray-600 mt-2 whitespace-pre-wrap"><strong>Notes:</strong> {item.guest.notes}</p>}
                                 </div>
                             ))}</div>
                         ) : (<p className="text-gray-600">This table is currently empty.</p>)}
@@ -457,34 +460,41 @@
                 const unassigned = [];
                 const tableAssignmentsMap = tables.reduce((acc, table) => { acc[table.internalId] = { guests: [], remainingSeats: table.capacity }; return acc; }, {});
                 guests.forEach(guest => {
-                    const assignedTableId = assignments[guest.id];
-                    if (assignedTableId && tableAssignmentsMap[assignedTableId]) {
-                        tableAssignmentsMap[assignedTableId].guests.push(guest);
-                        tableAssignmentsMap[assignedTableId].remainingSeats -= guest.size;
-                    } else { unassigned.push(guest); }
+                    const parts = assignments[guest.id] || [];
+                    let assignedTotal = 0;
+                    parts.forEach(p => {
+                        assignedTotal += p.seats;
+                        if (tableAssignmentsMap[p.tableId]) {
+                            tableAssignmentsMap[p.tableId].guests.push({ guest, assignedSeats: p.seats });
+                            tableAssignmentsMap[p.tableId].remainingSeats -= p.seats;
+                        }
+                    });
+                    if (assignedTotal < guest.size) {
+                        unassigned.push({ guest, remaining: guest.size - assignedTotal });
+                    }
                 });
 
                 const capacities = [];
-                const sorted = unassigned.slice().sort((a,b) => b.size - a.size);
-                sorted.forEach(g => {
+                const sorted = unassigned.slice().sort((a,b) => b.remaining - a.remaining);
+                sorted.forEach(({ remaining }) => {
                     let placed = false;
                     for (let i = 0; i < capacities.length; i++) {
-                        if (capacities[i] >= g.size) {
-                            capacities[i] -= g.size;
+                        if (capacities[i] >= remaining) {
+                            capacities[i] -= remaining;
                             placed = true;
                             break;
                         }
                     }
                     if (!placed) {
-                        capacities.push(DEFAULT_TABLE_CAPACITY - g.size);
+                        capacities.push(DEFAULT_TABLE_CAPACITY - remaining);
                     }
                 });
 
                 Object.values(tableAssignmentsMap).forEach(t => {
-                    t.guests.sort((a,b) => a.name.localeCompare(b.name, undefined, {sensitivity: 'base'}));
+                    t.guests.sort((a,b) => a.guest.name.localeCompare(b.guest.name, undefined, {sensitivity: 'base'}));
                 });
 
-                return { unassignedGuests: unassigned.sort((a,b) => a.name.localeCompare(b.name, undefined, {sensitivity: 'base'})), tableAssignments: tableAssignmentsMap, estimatedTables: capacities.length };
+                return { unassignedGuests: unassigned.sort((a,b) => a.guest.name.localeCompare(b.guest.name, undefined, {sensitivity: 'base'})), tableAssignments: tableAssignmentsMap, estimatedTables: capacities.length };
             }, [assignments, guests, tables]);
             
 
@@ -898,17 +908,12 @@
                     setConfirmModalState({ isOpen: true, guestId: guestId });
                 } else {
                     setGuests(currentGuests => currentGuests.map(g => g.id === guestId ? { ...g, size: newSize } : g));
-                    const assignedTableId = assignments[guestId];
-                    if (assignedTableId) {
-                        const tableData = tables.find(t => t.internalId === assignedTableId);
-                        const currentTableGuests = guests.filter(g => assignments[g.id] === assignedTableId && g.id !== guestId);
-                        const newTotal = currentTableGuests.reduce((sum, g) => sum + g.size, 0) + newSize;
-                        if (newTotal > tableData.capacity) {
-                            unassignGuest(guestId);
-                            // Find the guest name for the notification
-                            const guestToUpdate = guests.find(g => g.id === guestId);
-                            displayNotification(`"${guestToUpdate.name}" unassigned: new size (${newSize}) exceeds table capacity.`, 'info');
-                        }
+                    const parts = assignments[guestId] || [];
+                    const totalAssigned = parts.reduce((sum, p) => sum + p.seats, 0);
+                    if (totalAssigned > newSize) {
+                        unassignGuest(guestId);
+                        const guestToUpdate = guests.find(g => g.id === guestId);
+                        displayNotification(`"${guestToUpdate.name}" unassigned: new size (${newSize}) is less than currently assigned seats.`, 'info');
                     }
                 }
             };
@@ -933,12 +938,20 @@
 
             const assignGuestToTable = (guestId, tableId) => {
                 const guest = guests.find(g => g.id === guestId);
-                const { remainingSeats } = tableAssignments[tableId];
-                if (!guest) return;
-                if (guest.size > remainingSeats) {
-                    displayNotification(`Party of ${guest.size} is too large for this table.`, 'error');
-                } else {
-                    setAssignments(prev => ({ ...prev, [guestId]: tableId }));
+                const tableData = tableAssignments[tableId];
+                if (!guest || !tableData) return;
+                const parts = assignments[guestId] || [];
+                const assigned = parts.reduce((sum, p) => sum + p.seats, 0);
+                const remainingGuest = guest.size - assigned;
+                if (remainingGuest <= 0) return;
+                const seatsToAssign = Math.min(remainingGuest, tableData.remainingSeats);
+                if (seatsToAssign <= 0) {
+                    displayNotification('Not enough seats available at this table.', 'error');
+                    return;
+                }
+                const newParts = [...parts, { tableId, seats: seatsToAssign }];
+                setAssignments(prev => ({ ...prev, [guestId]: newParts }));
+                if (seatsToAssign === remainingGuest) {
                     setSelectedGuestId(null);
                 }
             };
@@ -1016,7 +1029,7 @@
                     >
                         Are you sure you want to remove the party "<strong>{guestToConfirm?.name}</strong>"? This action cannot be undone.
                     </ConfirmationModal>
-                    <ReservationDetailsModal table={modalTable} guests={modalGuests} onClose={() => setModalData(null)} onUnassign={handleUnassignInModal} onReassign={handleReassignInModal} onSizeChange={handleGuestSizeChange} />
+                    <ReservationDetailsModal table={modalTable} guests={modalGuests} assignments={assignments} tables={tables} onClose={() => setModalData(null)} onUnassign={handleUnassignInModal} onReassign={handleReassignInModal} onSizeChange={handleGuestSizeChange} />
                     <AddPartyModal isOpen={isAddPartyModalOpen} onClose={() => setIsAddPartyModalOpen(false)} onAddParty={handleAddParty} />
 
                     <header className="landscape-header p-4 sm:p-6 lg:p-4 w-full flex-shrink-0">
@@ -1052,7 +1065,7 @@
                                 </button>
                             </div>
                             <div className="overflow-y-auto flex-grow p-4" style={{ WebkitOverflowScrolling: 'touch' }}>
-                                {guests.length > 0 ? ( unassignedGuests.map(guest => <GuestCard key={guest.id} guest={guest} onSizeChange={handleGuestSizeChange} onNotesChange={handleGuestNotesChange} isSelected={selectedGuestId === guest.id} onClick={() => handleGuestCardClick(guest.id)} />)
+                                {guests.length > 0 ? ( unassignedGuests.map(item => <GuestCard key={item.guest.id} guest={item.guest} remaining={item.remaining} onSizeChange={handleGuestSizeChange} onNotesChange={handleGuestNotesChange} isSelected={selectedGuestId === item.guest.id} onClick={() => handleGuestCardClick(item.guest.id)} />)
                                 ) : (<div className="text-center text-gray-500 mt-10 p-4 bg-gray-50 rounded-lg"><h3 className="font-semibold text-lg">No Guests</h3><p className="text-sm">Import a guest list to get started.</p></div>)}
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -987,6 +987,7 @@
             };
 
             const handleReassignInModal = (guestId) => {
+                unassignGuest(guestId);
                 setSelectedGuestId(guestId);
                 setModalData(null);
                 const guest = guests.find(g => g.id === guestId);


### PR DESCRIPTION
## Summary
- allow large parties to split across multiple tables
- show remaining seats for partially seated parties
- show breakdown of split parties in table details

## Testing
- `node test/validateLayouts.js`

------
https://chatgpt.com/codex/tasks/task_e_688c145fa938832297c029627b975874