### PR TITLE
Prevent sidebar from moving on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,11 @@
             height: 100%;
             margin: 0;
         }
+        body {
+            overflow: hidden; /* Keep sidebar fixed by disabling page scroll */
+        }
         #root {
-            overflow: hidden; /* Prevent body scroll */
+            overflow: hidden;
         }
 
 


### PR DESCRIPTION
## Summary
- Disable body scrolling so the sidebar stays fixed while content panes handle their own scroll

## Testing
- `node test/validateLayouts.js`


------
https://chatgpt.com/codex/tasks/task_e_68a24d330cd8832280e14df6d09f89cd