### PR TITLE
Expand guest card hitbox for easier selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@
             ? (mergeSelected ? 'ring-2 ring-green-500' : 'ring-1 ring-transparent')
             : (isSelected ? 'ring-2 ring-blue-500' : 'ring-1 ring-transparent');
           return (
-            <div onClick={handleClick} className={`p-3 mb-2 rounded-lg shadow-md cursor-pointer flex flex-col items-start justify-center text-sm transition-all duration-200 ease-in-out bg-white hover:bg-gray-50 ${ringClass}`}>
+            <div onClick={handleClick} className={`w-full p-3 mb-2 rounded-lg shadow-md cursor-pointer flex flex-col items-start justify-center text-sm transition-all duration-200 ease-in-out bg-white hover:bg-gray-50 ${ringClass}`}>
               <div className="flex items-center justify-between w-full">
                 <div className="flex items-center space-x-2">
                   {isMerging && (

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
             };
 
             return (
-                <div className="mt-2 text-sm text-gray-700 w-full relative" onClick={(e) => e.stopPropagation()}>
+                <div className="mt-2 text-sm text-gray-700 w-full relative">
 
                     {isEditing ? (
                         <textarea
@@ -178,20 +178,23 @@
                             onChange={handleTextChange}
                             onBlur={handleSave}
                             onKeyDown={handleKeyDown}
+                            onClick={(e) => e.stopPropagation()}
+                            onMouseDown={(e) => e.stopPropagation()}
+                            onTouchStart={(e) => e.stopPropagation()}
                             className="w-full p-1 text-sm bg-white border border-indigo-300 rounded resize-none pr-6"
 
                             placeholder="Add a note..."
                             rows="1"
                         />
                     ) : (
-                        <div className={`w-full p-1 rounded min-h-[2.5rem] cursor-text whitespace-pre-wrap ${note ? 'text-gray-700' : 'text-gray-400 italic'}`}
+                        <div className={`w-full p-1 rounded min-h-[2.5rem] whitespace-pre-wrap select-none ${note ? 'text-gray-700' : 'text-gray-400 italic'}`}
                         >
                             {note || 'Add a note...'}
                         </div>
                     )}
                     {!isEditing && (
                         <button
-                            onClick={() => setIsEditing(true)}
+                            onClick={(e) => { e.stopPropagation(); setIsEditing(true); }}
                             className="absolute top-1 right-1 p-1 text-gray-500 hover:text-indigo-600"
                             title="Edit notes"
                         >


### PR DESCRIPTION
## Summary
- Make entire guest card selectable by expanding its container to full width

## Testing
- `node test/validateLayouts.js`


------
https://chatgpt.com/codex/tasks/task_e_68b71c1b9510832286b07337367bfbe4